### PR TITLE
fix: unfreeze pycountry version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.egg
 *.egg-info
 dist
+.eggs
 eggs
 parts
 bin
@@ -57,3 +58,9 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+
+# PyCharm
+.idea
+
+# pyenv
+.python-version

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,14 @@ ChangeLog
 =========
 
 
-`1.3.6 (unreleased) <https://github.com/scaleway/postal-address/compare/v1.3.5...develop>`_
+`1.4.0 (unreleased) <https://github.com/scaleway/postal-address/compare/v1.3.5...develop>`_
 -------------------------------------------------------------------------------------------
 
 .. note:: This version is not yet released and is under active development.
 
-* No changes yet.
+* Unfreeze pycountry version and bump to ``pycountry >= 18.5.26``.
+* Refactor country aliases with better categories.
+* Some subdivisions names were updated, such as ``FR-O`` to ``FR-HDF``
 
 
 `1.3.5 (2017-10-03) <https://github.com/scaleway/postal-address/compare/v1.3.4...v1.3.5>`_

--- a/postal_address/__init__.py
+++ b/postal_address/__init__.py
@@ -9,7 +9,7 @@
 
 import sys
 
-__version__ = '1.3.6'
+__version__ = '1.4.0'
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3

--- a/postal_address/address.py
+++ b/postal_address/address.py
@@ -378,7 +378,7 @@ class Address(object):
 
                         # Build the list of substitute values that are
                         # equivalent to our new normalized target.
-                        alias_values = set([new_value])
+                        alias_values = {new_value}
                         if field_id == 'country_code':
                             # Allow normalization if the current country code
                             # is the direct parent of a subdivision which also
@@ -390,9 +390,8 @@ class Address(object):
                         # substitute to our new normalized value.
                         if current_value not in alias_values:
                             raise InvalidAddress(
-                                inconsistent_fields=set([
-                                    tuple(sorted((
-                                        field_id, 'subdivision_code')))]),
+                                inconsistent_fields={tuple(sorted((
+                                    field_id, 'subdivision_code')))},
                                 extra_msg="{} subdivision is trying to replace"
                                 " {}={!r} field by {}={!r}".format(
                                     self.subdivision_code,
@@ -408,45 +407,78 @@ class Address(object):
         raise an exception at the end, for the whole address object. Our custom
         exception will provide a detailed status of bad fields.
         """
-        # Keep a classification of bad fields along the validation process.
-        required_fields = set()
-        invalid_fields = dict()
-        inconsistent_fields = set()
 
-        # Check that all required fields are set.
+        required_fields = self.check_required_fields()
+        invalid_fields = self.check_invalid_fields(required_fields)
+        inconsistent_fields = self.check_inconsistent_fields(required_fields,
+                                                             invalid_fields)
+
+        # Raise our custom exception if any value is wrong.
+        if required_fields or invalid_fields or inconsistent_fields:
+            raise InvalidAddress(
+                required_fields, invalid_fields, inconsistent_fields)
+
+    def check_required_fields(self):
+        """Check that all required fields are set.
+
+        :return: The set of unset thus required fields.
+        """
+        required_fields = set()
         for field_id in self.REQUIRED_FIELDS:
             if not getattr(self, field_id):
                 required_fields.add(field_id)
+        return required_fields
 
-        # Check all fields for invalidity, only if not previously flagged as
-        # required.
+    def check_invalid_fields(self, required_fields):
+        """Check all fields for invalidity, only if not previously flagged as
+        required.
+
+        :param required_fields:
+        :return:
+        """
+        invalid_fields = dict()
         if 'country_code' not in required_fields:
             # Check that the country code exists.
             try:
                 countries.get(alpha_2=self.country_code)
             except KeyError:
                 invalid_fields['country_code'] = self.country_code
+
         if self.subdivision_code and 'subdivision_code' not in required_fields:
             # Check that the country code exists.
             try:
                 subdivisions.get(code=self.subdivision_code)
             except KeyError:
                 invalid_fields['subdivision_code'] = self.subdivision_code
+        return invalid_fields
 
-        # Check country consistency against subdivision, only if none of the
-        # two fields were previously flagged as required or invalid.
-        if self.subdivision_code and not set(
-                ['country_code', 'subdivision_code']).intersection(
-                    required_fields.union(invalid_fields)) and \
-                country_from_subdivision(
-                    self.subdivision_code) != self.country_code:
-            inconsistent_fields.add(
-                tuple(sorted(('country_code', 'subdivision_code'))))
+    def check_inconsistent_fields(self, required_fields, invalid_fields):
+        """Check country consistency against subdivision, only if none of the
+         two fields were previously flagged as required or invalid.
 
-        # Raise our custom exception at last.
-        if required_fields or invalid_fields or inconsistent_fields:
-            raise InvalidAddress(
-                required_fields, invalid_fields, inconsistent_fields)
+        :param required_fields: The set of missing required fields.
+        :param invalid_fields: The set of invalid fields.
+        :return:
+        """
+        inconsistent_fields = set()
+        any_wrong_field = required_fields.union(invalid_fields)
+        consistency_fields = {'country_code', 'subdivision_code'}
+        inconsistency = consistency_fields.intersection(any_wrong_field)
+        if not inconsistency and not self.valid_subdivision_country():
+            inconsistent_fields.add(tuple(sorted(consistency_fields)))
+        return inconsistent_fields
+
+    def valid_subdivision_country(self):
+        """Validates that the country attached to the subdivision is
+        the same as the Address country_code.
+
+        :return: True if the subdivision country is the same as the country,
+        False otherwise.
+        """
+        if not self.subdivision_code:
+            return True
+        inferred_country = country_from_subdivision(self.subdivision_code)
+        return inferred_country == self.country_code
 
     @property
     def valid(self):

--- a/postal_address/address.py
+++ b/postal_address/address.py
@@ -715,9 +715,9 @@ def subdivision_metadata(subdivision):
     subdiv_type_id = subdivision_type_id(subdivision)
     metadata = {
         '{}'.format(subdiv_type_id): subdivision,
-        # Rename code to slug to avoid overriding 'country_code' in some cases
+        # Rename 'code' to 'area_code' to avoid overriding 'country_code'
         # See https://github.com/scaleway/postal-address/issues/16
-        '{}_slug'.format(subdiv_type_id): subdivision.code,
+        '{}_area_code'.format(subdiv_type_id): subdivision.code,
         '{}_name'.format(subdiv_type_id): subdivision.name,
         '{}_type_name'.format(subdiv_type_id): subdivision.type}
 

--- a/postal_address/address.py
+++ b/postal_address/address.py
@@ -319,7 +319,11 @@ class Address(object):
         # Normalize spaces.
         for field_id, field_value in self.items():
             if isinstance(field_value, basestring):
-                self[field_id] = ' '.join(field_value.split())
+                try:
+                    self[field_id] = ' '.join(field_value.split())
+                except KeyError:
+                    # Invalid field_id, usually all the 'subdivision_metadata'
+                    pass
 
         # Reset empty and blank strings.
         empty_fields = [f_id for f_id, f_value in self.items() if not f_value]
@@ -350,7 +354,7 @@ class Address(object):
             if self.subdivision_code:
                 self.country_code = None
 
-        # Automaticcaly populate address fields with metadata extracted from
+        # Automatically populate address fields with metadata extracted from
         # all subdivision parents.
         if self.subdivision_code:
             parent_metadata = {
@@ -679,7 +683,9 @@ def subdivision_metadata(subdivision):
     subdiv_type_id = subdivision_type_id(subdivision)
     metadata = {
         '{}'.format(subdiv_type_id): subdivision,
-        '{}_code'.format(subdiv_type_id): subdivision.code,
+        # Rename code to slug to avoid overriding 'country_code' in some cases
+        # See https://github.com/scaleway/postal-address/issues/16
+        '{}_slug'.format(subdiv_type_id): subdivision.code,
         '{}_name'.format(subdiv_type_id): subdivision.name,
         '{}_type_name'.format(subdiv_type_id): subdivision.type}
 

--- a/postal_address/tests/test_address.py
+++ b/postal_address/tests/test_address.py
@@ -611,7 +611,7 @@ class TestAddressValidation(unittest.TestCase):
             line1='Barack 31',
             postal_code='XXX No postal code on this atoll',
             city_name='Clipperton Island',
-            country_code='CP') # This is actually a non existing country code
+            country_code='CP')  # This is actually a non existing country code
         self.assertEqual(address.country_code, 'FR')
         self.assertEqual(address.subdivision_code, 'FR-CP')
 

--- a/postal_address/tests/test_address.py
+++ b/postal_address/tests/test_address.py
@@ -25,8 +25,8 @@ from pycountry import countries, subdivisions
 from postal_address.address import Address, InvalidAddress, random_address
 from postal_address.territory import (
     supported_country_codes,
-    supported_territory_codes
-)
+    supported_territory_codes,
+    supported_subdivision_codes)
 
 
 class TestAddressIO(unittest.TestCase):
@@ -251,7 +251,7 @@ class TestAddressIO(unittest.TestCase):
             line1='Dummy address',
             postal_code='F-12345',
             city_name='Dummy city',
-            country_code='CP')
+            country_code='CP')  # This is not an official country_code
         self.assertEquals(address.render(), textwrap.dedent("""\
             Dummy address
             F-12345 - Dummy city
@@ -274,7 +274,7 @@ class TestAddressIO(unittest.TestCase):
             line1='Dummy address',
             postal_code='F-12345',
             city_name='Dummy city',
-            country_code='IC')
+            country_code='IC')  # This is not an official country_code
         self.assertEquals(address.render(), textwrap.dedent("""\
             Dummy address
             F-12345 - Dummy city
@@ -611,7 +611,15 @@ class TestAddressValidation(unittest.TestCase):
             line1='Barack 31',
             postal_code='XXX No postal code on this atoll',
             city_name='Clipperton Island',
-            country_code='CP')
+            country_code='CP') # This is actually a non existing country code
+        self.assertEqual(address.country_code, 'FR')
+        self.assertEqual(address.subdivision_code, 'FR-CP')
+
+        address = Address(
+            line1='Barack 31',
+            postal_code='XXX No postal code on this atoll',
+            city_name='Clipperton Island',
+            subdivision_code='FR-CP')
         self.assertEqual(address.country_code, 'FR')
         self.assertEqual(address.subdivision_code, 'FR-CP')
 
@@ -928,10 +936,18 @@ class TestAddressValidation(unittest.TestCase):
     def test_all_territory_codes(self):
         """ Validate & render random addresses with all supported territories.
         """
-        for territory_code in supported_territory_codes():
+        for territory_code in supported_subdivision_codes():
             address = random_address()
             address.country_code = None
             address.subdivision_code = territory_code
+            address.normalize(strict=False)
+            address.validate()
+            address.render()
+
+        for territory_code in supported_country_codes():
+            address = random_address()
+            address.country_code = territory_code
+            address.subdivision_code = None
             address.normalize(strict=False)
             address.validate()
             address.render()

--- a/postal_address/tests/test_address.py
+++ b/postal_address/tests/test_address.py
@@ -268,6 +268,7 @@ class TestAddressIO(unittest.TestCase):
         self.assertEquals(address.render(), textwrap.dedent("""\
             Dummy address
             F-12345 - Dummy city
+            La Réunion
             Réunion"""))
         address = Address(
             line1='Dummy address',
@@ -731,7 +732,7 @@ class TestAddressValidation(unittest.TestCase):
         self.assertEquals(
             address.metropolitan_department, subdivisions.get(code='FR-59'))
         self.assertEquals(
-            address.metropolitan_department_code, 'FR-59')
+            address.metropolitan_department_slug, 'FR-59')
         self.assertEquals(
             address.metropolitan_department_name, 'Nord')
         self.assertEquals(
@@ -739,11 +740,11 @@ class TestAddressValidation(unittest.TestCase):
             'Metropolitan department')
 
         self.assertEquals(
-            address.metropolitan_region, subdivisions.get(code='FR-O'))
+            address.metropolitan_region, subdivisions.get(code='FR-HDF'))
         self.assertEquals(
-            address.metropolitan_region_code, 'FR-O')
+            address.metropolitan_region_slug, 'FR-HDF')
         self.assertEquals(
-            address.metropolitan_region_name, 'Nord - Pas-de-Calais')
+            address.metropolitan_region_name, 'Hauts-de-France')
         self.assertEquals(
             address.metropolitan_region_type_name,
             'Metropolitan region')
@@ -775,7 +776,7 @@ class TestAddressValidation(unittest.TestCase):
         self.assertEquals(
             address.city, subdivisions.get(code='GB-LND'))
         self.assertEquals(
-            address.city_code, 'GB-LND')
+            address.city_slug, 'GB-LND')
         self.assertEquals(
             address.city_name, 'London, City of')
         self.assertEquals(
@@ -783,9 +784,6 @@ class TestAddressValidation(unittest.TestCase):
 
         self.assertEquals(address.country_code, 'GB')
 
-    @unittest.skip(
-        "Need to fix edge-case in the subdivision/state/country normalization "
-        "code. See #16.")
     def test_subdivision_derived_country(self):
         address = Address(
             line1='Senate House',
@@ -916,9 +914,6 @@ class TestAddressValidation(unittest.TestCase):
         self.assertEqual(address.country_name, 'Taiwan')
         self.assertEqual(address.subdivision_code, 'TW-TNN')
 
-    @unittest.skip(
-        "Need to fix edge-case in the subdivision/state/country normalization "
-        "code. See #16.")
     def test_all_country_codes(self):
         """ Validate & render random addresses with all supported countries.
         """
@@ -930,9 +925,6 @@ class TestAddressValidation(unittest.TestCase):
             address.validate()
             address.render()
 
-    @unittest.skip(
-        "Need to fix edge-case in the subdivision/state/country normalization "
-        "code. See #16.")
     def test_all_territory_codes(self):
         """ Validate & render random addresses with all supported territories.
         """

--- a/postal_address/tests/test_address.py
+++ b/postal_address/tests/test_address.py
@@ -740,7 +740,7 @@ class TestAddressValidation(unittest.TestCase):
         self.assertEquals(
             address.metropolitan_department, subdivisions.get(code='FR-59'))
         self.assertEquals(
-            address.metropolitan_department_slug, 'FR-59')
+            address.metropolitan_department_area_code, 'FR-59')
         self.assertEquals(
             address.metropolitan_department_name, 'Nord')
         self.assertEquals(
@@ -750,7 +750,7 @@ class TestAddressValidation(unittest.TestCase):
         self.assertEquals(
             address.metropolitan_region, subdivisions.get(code='FR-HDF'))
         self.assertEquals(
-            address.metropolitan_region_slug, 'FR-HDF')
+            address.metropolitan_region_area_code, 'FR-HDF')
         self.assertEquals(
             address.metropolitan_region_name, 'Hauts-de-France')
         self.assertEquals(
@@ -784,7 +784,7 @@ class TestAddressValidation(unittest.TestCase):
         self.assertEquals(
             address.city, subdivisions.get(code='GB-LND'))
         self.assertEquals(
-            address.city_slug, 'GB-LND')
+            address.city_area_code, 'GB-LND')
         self.assertEquals(
             address.city_name, 'London, City of')
         self.assertEquals(

--- a/postal_address/tests/test_territory.py
+++ b/postal_address/tests/test_territory.py
@@ -121,10 +121,10 @@ class TestTerritory(unittest.TestCase):
     def test_territory_parents_codes(self):
         self.assertEquals(
             list(territory_parents_codes('FR-59')),
-            ['FR-59', 'FR-O', 'FR'])
+            ['FR-59', 'FR-HDF', 'FR'])
         self.assertEquals(
             list(territory_parents_codes('FR-59', include_country=False)),
-            ['FR-59', 'FR-O'])
+            ['FR-59', 'FR-HDF'])
         self.assertEquals(
             list(territory_parents_codes('FR')),
             ['FR'])
@@ -247,3 +247,8 @@ class TestTerritory(unittest.TestCase):
                     self.assertTrue(hasattr(simple_address, metadata_id))
                 else:
                     self.assertFalse(hasattr(simple_address, metadata_id))
+
+    def test_subdivision_parent_code(self):
+        # See https://bitbucket.org/flyingcircus/pycountry/issues/13389
+        self.assertEqual("GB-ENG", subdivisions.get(code='GB-STS').parent_code)
+        self.assertEqual("CZ-20", subdivisions.get(code='CZ-205').parent_code)

--- a/postal_address/tests/test_territory.py
+++ b/postal_address/tests/test_territory.py
@@ -43,6 +43,7 @@ from postal_address.territory import (
 PYCOUNTRY_CC = set(map(attrgetter('alpha_2'), countries))
 PYCOUNTRY_SUB = set(map(attrgetter('code'), subdivisions))
 
+
 class TestTerritory(unittest.TestCase):
     # Test territory utils
 
@@ -90,7 +91,8 @@ class TestTerritory(unittest.TestCase):
             # recognized by pycountry right away.
             self.assertIn(alias_code, PYCOUNTRY_CC.union(PYCOUNTRY_SUB))
 
-        for country_code, alias_code in FOREIGN_TERRITORIES_ALIAS_TO_COUNTRY.items():
+        for country_code, alias_code in FOREIGN_TERRITORIES_ALIAS_TO_COUNTRY \
+                .items():
             self.assertNotIn(country_code, PYCOUNTRY_CC)
             self.assertIn(alias_code, PYCOUNTRY_CC.union(PYCOUNTRY_SUB))
 
@@ -210,20 +212,20 @@ class TestTerritory(unittest.TestCase):
 
     def test_subdivision_type_id_city_classification(self):
         city_like_subdivisions = [
-            'TM-S',    # Aşgabat, Turkmenistan, City
+            'TM-S',  # Aşgabat, Turkmenistan, City
             'TW-CYI',  # Chiay City, Taiwan, Municipality
             'TW-TPE',  # Taipei City, Taiwan, Special Municipality
-            'ES-ML',   # Melilla, Spain, Autonomous city
+            'ES-ML',  # Melilla, Spain, Autonomous city
             'GB-LND',  # City of London, United Kingdom, City corporation
-            'KP-01',   # P’yŏngyang, North Korea, Capital city
-            'KP-13',   # Nasŏn (Najin-Sŏnbong), North Korea, Special city
-            'KR-11',   # Seoul Teugbyeolsi, South Korea, Capital Metropolitan
-                       # City
-            'HU-HV',   # Hódmezővásárhely, Hungary, City with county rights
+            'KP-01',  # P’yŏngyang, North Korea, Capital city
+            'KP-13',  # Nasŏn (Najin-Sŏnbong), North Korea, Special city
+            'KR-11',  # Seoul Teugbyeolsi, South Korea, Capital Metropolitan
+            # City
+            'HU-HV',  # Hódmezővásárhely, Hungary, City with county rights
             'LV-RIX',  # Rīga, Latvia, Republican City
-            'ME-15',   # Plužine, Montenegro, Municipality
+            'ME-15',  # Plužine, Montenegro, Municipality
             'NL-BQ1',  # Bonaire, Netherlands, Special municipality
-            'KH-12',   # Phnom Penh, Cambodia, Autonomous municipality
+            'KH-12',  # Phnom Penh, Cambodia, Autonomous municipality
         ]
         for subdiv_code in city_like_subdivisions:
             self.assertEquals(

--- a/postal_address/tests/test_territory.py
+++ b/postal_address/tests/test_territory.py
@@ -38,7 +38,7 @@ from postal_address.territory import (
     territory_attachment,
     territory_children_codes,
     territory_parents_codes,
-    FOREIGN_TERRITORIES_MAPPING, FOREIGN_TERRITORIES_ALIAS_TO_COUNTRY)
+    FOREIGN_TERRITORIES_MAPPING, RESERVED_COUNTRY_CODES)
 
 PYCOUNTRY_CC = set(map(attrgetter('alpha_2'), countries))
 PYCOUNTRY_SUB = set(map(attrgetter('code'), subdivisions))
@@ -91,8 +91,7 @@ class TestTerritory(unittest.TestCase):
             # recognized by pycountry right away.
             self.assertIn(alias_code, PYCOUNTRY_CC.union(PYCOUNTRY_SUB))
 
-        for country_code, alias_code in FOREIGN_TERRITORIES_ALIAS_TO_COUNTRY \
-                .items():
+        for country_code, alias_code in RESERVED_COUNTRY_CODES.items():
             self.assertNotIn(country_code, PYCOUNTRY_CC)
             self.assertIn(alias_code, PYCOUNTRY_CC.union(PYCOUNTRY_SUB))
 
@@ -147,6 +146,9 @@ class TestTerritory(unittest.TestCase):
         # Check country alias to a subdivision.
         self.assertEquals(
             list(territory_parents_codes('SH-TA')),
+            ['SH-TA', 'SH'])
+        self.assertEquals(
+            list(territory_parents_codes('TA')),
             ['SH-TA', 'SH'])
 
         # Check subdivision alias to a country.
@@ -274,25 +276,23 @@ class TestTerritory(unittest.TestCase):
         # Sub-territories will not change by default
         self.assertEqual("BQ", normalize_territory_code("BQ"))
         self.assertEqual("GP", normalize_territory_code("FR-GP"))
-        # TODO: Is it normal to not retrieve alpha2 ?
-        # self.assertEqual("BQ", normalize_territory_code("NL-BQ1"))
+
         self.assertEqual("BQ-BO", normalize_territory_code("NL-BQ1"))
 
     def test_normalize_territory_code_with_foreign_territory(self):
         resolved = normalize_territory_code("BQ",
-                                            resole_foreign_territory=True)
+                                            resolve_top_country=True)
         self.assertEqual("NL", resolved)
 
         resolved = normalize_territory_code("VI",
-                                            resole_foreign_territory=True)
+                                            resolve_top_country=True)
         self.assertEqual("US", resolved)
 
         resolved = normalize_territory_code("FR-GP",
-                                            resole_foreign_territory=True)
+                                            resolve_top_country=True)
         self.assertEqual("FR", resolved)
 
         resolved = normalize_territory_code("NL-BQ1",
-                                            resole_foreign_territory=True)
-        # TODO: Is it normal to not retrieve alpha2 ?
-        # self.assertEqual("NL", resolved)
+                                            resolve_top_country=True)
+
         self.assertEqual("BQ-BO", resolved)

--- a/postal_address/tests/test_territory.py
+++ b/postal_address/tests/test_territory.py
@@ -31,9 +31,11 @@ from postal_address.territory import (
     country_aliases,
     country_from_subdivision,
     default_subdivision_code,
+    normalize_territory_code,
     supported_country_codes,
     supported_subdivision_codes,
     supported_territory_codes,
+    territory_attachment,
     territory_children_codes,
     territory_parents_codes
 )
@@ -252,3 +254,37 @@ class TestTerritory(unittest.TestCase):
         # See https://bitbucket.org/flyingcircus/pycountry/issues/13389
         self.assertEqual("GB-ENG", subdivisions.get(code='GB-STS').parent_code)
         self.assertEqual("CZ-20", subdivisions.get(code='CZ-205').parent_code)
+
+    def test_foreign_territory_mapping(self):
+        self.assertEqual("FR", territory_attachment("GP"))
+        self.assertEqual("NL", territory_attachment("BQ"))
+
+    def test_normalize_territory_code(self):
+        self.assertEqual("GR", normalize_territory_code("EL"))
+        self.assertEqual("FR", normalize_territory_code("FX"))
+        self.assertEqual("TW", normalize_territory_code("CN-71"))
+        # Sub-territories will not change by default
+        self.assertEqual("BQ", normalize_territory_code("BQ"))
+        self.assertEqual("GP", normalize_territory_code("FR-GP"))
+        # TODO: Is it normal to not retrieve alpha2 ?
+        # self.assertEqual("BQ", normalize_territory_code("NL-BQ1"))
+        self.assertEqual("BQ-BO", normalize_territory_code("NL-BQ1"))
+
+    def test_normalize_territory_code_with_foreign_territory(self):
+        resolved = normalize_territory_code("BQ",
+                                            resole_foreign_territory=True)
+        self.assertEqual("NL", resolved)
+
+        resolved = normalize_territory_code("VI",
+                                            resole_foreign_territory=True)
+        self.assertEqual("US", resolved)
+
+        resolved = normalize_territory_code("FR-GP",
+                                            resole_foreign_territory=True)
+        self.assertEqual("FR", resolved)
+
+        resolved = normalize_territory_code("NL-BQ1",
+                                            resole_foreign_territory=True)
+        # TODO: Is it normal to not retrieve alpha2 ?
+        # self.assertEqual("NL", resolved)
+        self.assertEqual("BQ-BO", resolved)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 universal = 1
 
 [bumpversion]
-current_version = 1.3.6
+current_version = 1.4.0
 files = ./postal_address/__init__.py ./CHANGES.rst
 allow_dirty = True
 commit = False

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ DEPENDENCIES = [
     # TODO: subdivision definitions are broken for Czech Republic starting with
     # PyCountry 16.11.27. See:
     # https://bitbucket.org/flyingcircus/pycountry/issues/13389
-    'pycountry >= 16.11.08, < 16.11.27',
+    'pycountry >= 18.5.26',
 ]
 
 EXTRA_DEPENDENCIES = {

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,6 @@ PACKAGE_NAME = MODULE_NAME.replace('_', '-')
 DEPENDENCIES = [
     'boltons',
     'Faker >= 0.8.4',
-    # TODO: subdivision definitions are broken for Czech Republic starting with
-    # PyCountry 16.11.27. See:
-    # https://bitbucket.org/flyingcircus/pycountry/issues/13389
     'pycountry >= 18.5.26',
 ]
 


### PR DESCRIPTION
This PR is mostly to fix the compatibility issue with `pycountry` (`country_code` being sometimes overridden). But I also tried to refactor the territory management and add a mapping of foreign territories.

I tried to understand and separated as well as possible the concepts you had behind the territories management. It's still far from perfect, but doesn't seem to break the behavior you intended to create. Tell me if it remains understandable on your side.

Please tell me if anything seems off in this PR since it has quite some changes ;)

Closes #16, #11 